### PR TITLE
Add status messages for QR and Info pages

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -35,6 +35,7 @@ void displayBoundaryBox()
 
 void displayInfoScreen()
 {
+    displayStatusMessage("Rendering info page...");
     Serial.printf("Rendering info page\n");
     static char buff[1024];
     esp_chip_info_t chip_info;

--- a/src/qr.cpp
+++ b/src/qr.cpp
@@ -6,6 +6,7 @@ void renderQR(QRCode qrcode, uint32_t x, uint32_t y, uint32_t size);
 
 void displayWiFiQR()
 {
+    displayStatusMessage("Rendering WiFi QR code...");
     Serial.printf("Rendering wifi QR Code\n");
     char buf[1024];
     snprintf(buf, 1024, "WIFI:S:%s;T:WPA;P:%s;;", QR_WIFI_NAME, QR_WIFI_PASSWORD);


### PR DESCRIPTION
My Inkplate 10 has the 3D printed case that was part of the preorder bundle. Unfortunately this case has _very_ flaky touch sensitivity on the buttons and I've found that I can often look silly pushing the touchpoint multiple times waiting for the device to do something.

The `displayStatusMessage` command called very early in the display process provides more rapid feedback that the device actually got my input. This is especially handy when it's coming out of sleep and going to take a bit to display anything.

This PR adds status messages prior to the refresh of the screen, so you'll see the status message a few moments before the whole screen refreshes. This clears the status message and displays the rest of the screen nicely.