### PR TITLE
add parameter refresh to mqtt activity for dynamic sleep time override

### DIFF
--- a/src/homeplate.h
+++ b/src/homeplate.h
@@ -75,6 +75,7 @@ void checkBootPads();
 #define TIME_TO_SLEEP_SEC (TIME_TO_SLEEP_MIN * 60)    // How long ESP32 will be in deep sleep (in seconds)
 #define TIME_TO_QUICK_SLEEP_SEC 5 * 60 // 5 minutes. How long ESP32 will be in deep sleep (in seconds) for short activities
 void startSleep();
+void setSleepRefresh(uint32_t sec);
 void setSleepDuration(uint32_t sec);
 void gotoSleepNow();
 

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -379,6 +379,20 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
     Serial.printf("\n");
     const char *action = doc["action"];
 
+    if (doc.containsKey("refresh"))
+    {
+      int refresh = doc["refresh"].as<int>();
+      Serial.printf("[MQTT][REFRESH]: %d\n", refresh);
+      if (refresh > 0 && refresh < 86400)
+      {
+        setSleepRefresh((uint32_t) refresh);
+      }
+      else
+      {
+        Serial.printf("[MQTT][ERROR] refresh value is out of range\n");
+      }
+    }
+
     if (strncmp("qr", action, 3) == 0)
     {
       startActivity(GuestWifi);
@@ -446,6 +460,7 @@ void startMQTTTask()
   // set deserialization filter
   filter["action"] = true;
   filter["message"] = true;
+  filter["refresh"] = true;
 
   mqttClient.setClientId(HOSTNAME);
   mqttClient.setServer(MQTT_HOST, MQTT_PORT);

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -23,7 +23,7 @@ void gotoSleepNow()
     Serial.println("[SLEEP] prepping for sleep");
     if (sleepRefresh > 0)
     {
-        Serial.printf("[SLEEP] overriding sleep %d with %d\n", sec, sleepRefresh);
+        Serial.printf("[SLEEP] overriding sleep %d with %d\n", sleepDuration, sleepRefresh);
         sleepDuration = sleepRefresh;
         sleepRefresh = 0;
     }

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -6,10 +6,25 @@
 
 static unsigned long sleepTime;
 uint32_t sleepDuration = TIME_TO_SLEEP_SEC;
+uint32_t sleepRefresh = 0;
+
+void setSleepRefresh(uint32_t sec)
+{
+    sleepRefresh = sec;
+}
 
 void setSleepDuration(uint32_t sec)
 {
-    sleepDuration = sec;
+    if (sleepRefresh > 0)
+    {
+        Serial.printf("[SLEEP] overriding sleep %d with %d\n", sec, sleepRefresh);
+        sleepDuration = sleepRefresh;
+        sleepRefresh = 0;
+    }
+    else
+    {
+        sleepDuration = sec;
+    }
 }
 
 void gotoSleepNow()

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -15,21 +15,18 @@ void setSleepRefresh(uint32_t sec)
 
 void setSleepDuration(uint32_t sec)
 {
+    sleepDuration = sec;
+}
+
+void gotoSleepNow()
+{
+    Serial.println("[SLEEP] prepping for sleep");
     if (sleepRefresh > 0)
     {
         Serial.printf("[SLEEP] overriding sleep %d with %d\n", sec, sleepRefresh);
         sleepDuration = sleepRefresh;
         sleepRefresh = 0;
     }
-    else
-    {
-        sleepDuration = sec;
-    }
-}
-
-void gotoSleepNow()
-{
-    Serial.println("[SLEEP] prepping for sleep");
 
     i2cStart();
     // disconnect WiFi as it's no longer needed


### PR DESCRIPTION
Useful for having a certain activity displayed for a shorter time range or having more frequent updates.
By using the activity/run topic, it only overwrites the sleep duration once, so no need to keep track of setting
the interval up and down manually.

Usage example:
I have an automation for commute times that runs every 5 minutes in the morning between 6 and 9.
After the sensor update I send mqtt.publish({"action": "hass", "refresh": "300"}) to have a shorter update interval
for the next run so the information on the display is more up-to-date.