### PR TITLE
remove unnecessary check for qr activity, broken by change #15

### DIFF
--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -100,12 +100,8 @@ void runActivities(void *params)
             // delaySleep(10);
             break;
         case GuestWifi:
-            // only change activities if necessary
-            if (activityCurrent != GuestWifi)
-            {
-                setSleepDuration(TIME_TO_QUICK_SLEEP_SEC);
-                displayWiFiQR();
-            }
+            setSleepDuration(TIME_TO_QUICK_SLEEP_SEC);
+            displayWiFiQR();
             break;
         case Info:
             setSleepDuration(TIME_TO_QUICK_SLEEP_SEC);


### PR DESCRIPTION
The change in PR #15 broke the qr code check, so qr is never displayed. Remove unnecessary check to make it work again