### PR TITLE
feat: InkPlate lib update to latest version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ lib_deps =
   ; >1.2.3 - any version greater than 1.2.3. >=, <, and <= are also possible
   ; >0.1.0,!=0.2.0,<0.3.0 - any version greater than 0.1.0, not equal to 0.2.0 and less than 0.3.0
   
-  https://github.com/e-radionicacom/Inkplate-Arduino-library @ 5.7.1
+  https://github.com/e-radionicacom/Inkplate-Arduino-library @ 6.0.0
   arduino-libraries/NTPClient @ 3.2.1 ; NTP client
   paulstoffregen/Time @ 1.6.1
   jchristensen/Timezone @ 1.2.4 ; for timezone and DST calculations

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -9,10 +9,10 @@
 // read a byte from the expander
 unsigned int readMCPRegister(const byte reg)
 {
-    Wire.beginTransmission(MCP23017_INT_ADDR);
+    Wire.beginTransmission(MCP23017_INTFA);
     Wire.write(reg);
     Wire.endTransmission();
-    Wire.requestFrom(MCP23017_INT_ADDR, 1);
+    Wire.requestFrom(MCP23017_INTFA, 1);
     return Wire.read();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,9 +51,9 @@ void setup()
     display.begin();             // Init Inkplate library (you should call this function ONLY ONCE)
     display.rtcClearAlarmFlag(); // Clear alarm flag from any previous alarm
     // set which pads can allow wakeup
-    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD1, RISING);
-    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD2, RISING);
-    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD3, RISING);
+    display.setIntPinInternal(MCP23017_INTFA, display.ioRegsInt, PAD1, RISING);
+    display.setIntPinInternal(MCP23017_INTFA, display.ioRegsInt, PAD2, RISING);
+    display.setIntPinInternal(MCP23017_INTFA, display.ioRegsInt, PAD3, RISING);
     pinMode(WAKE_BUTTON, INPUT_PULLUP);
 
     // setup display

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -35,7 +35,7 @@ void gotoSleepNow()
 
     // set MCP interrupts
     if (TOUCHPAD_ENABLE)
-        display.setIntOutputInternal(MCP23017_INT_ADDR, display.mcpRegsInt, 1, false, false, HIGH);
+        display.setIntOutputInternal(MCP23017_INTFA, display.ioRegsInt, 1, false, false, HIGH);
     i2cEnd();
 
     // Go to sleep for TIME_TO_SLEEP seconds

--- a/vcom_src/vcom.cpp
+++ b/vcom_src/vcom.cpp
@@ -54,7 +54,7 @@ void programEEPROM()
     if (EEPROM.read(EEPROMaddress) != 170)
     {
         Serial.println("Vcom being set...");
-        display.pinModeInternal(MCP23017_INT_ADDR, mcpRegsInt, 6, INPUT_PULLUP);
+        display.pinModeInternal(MCP23017_INTFA, mcpRegsInt, 6, INPUT_PULLUP);
         writeVCOMToEEPROM(vcomVoltage);
         EEPROM.write(EEPROMaddress, 170);
         EEPROM.commit();
@@ -92,10 +92,10 @@ void writeVCOMToEEPROM(double v)
     int vcomL = vcom & 0xFF;
     // First, we have to power up TPS65186
     // Pull TPS65186 WAKEUP pin to High
-    display.digitalWriteInternal(MCP23017_INT_ADDR, mcpRegsInt, 3, HIGH);
+    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 3, HIGH);
 
     // Pull TPS65186 PWR pin to High
-    display.digitalWriteInternal(MCP23017_INT_ADDR, mcpRegsInt, 4, HIGH);
+    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 4, HIGH);
     delay(10);
 
     // Send to TPS65186 first 8 bits of VCOM
@@ -113,23 +113,23 @@ void writeVCOMToEEPROM(double v)
     do
     {
         delay(1);
-    } while (display.digitalReadInternal(MCP23017_INT_ADDR, mcpRegsInt, 6));
+    } while (display.digitalReadInternal(MCP23017_INTFA, mcpRegsInt, 6));
 
     // Clear Interrupt flag by reading INT1 register
     readReg(0x07);
 
     // Now, power off whole TPS
     // Pull TPS65186 WAKEUP pin to Low
-    display.digitalWriteInternal(MCP23017_INT_ADDR, mcpRegsInt, 3, LOW);
+    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 3, LOW);
 
     // Pull TPS65186 PWR pin to Low
-    display.digitalWriteInternal(MCP23017_INT_ADDR, mcpRegsInt, 4, LOW);
+    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 4, LOW);
 
     // Wait a little bit...
     delay(1000);
 
     // Power up TPS again
-    display.digitalWriteInternal(MCP23017_INT_ADDR, mcpRegsInt, 3, HIGH);
+    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 3, HIGH);
 
     delay(10);
 


### PR DESCRIPTION
## Why?
Building the project it is (strangely) produces an error related to the new InkPlate lib.
```
Removing unused dependencies...
Library Manager: Installing git+https://github.com/e-radionicacom/Inkplate-Arduino-library @ 5.7.1
git version 2.37.1 (Apple Git-137.1)
Cloning into '/Users/mmornati/.platformio/.cache/tmp/pkg-installing-y2dxkhzi'...
remote: Enumerating objects: 1020, done.
remote: Counting objects: 100% (1020/1020), done.
remote: Compressing objects: 100% (757/757), done.
remote: Total 1020 (delta 340), reused 747 (delta 247), pack-reused 0
Receiving objects: 100% (1020/1020), 15.35 MiB | 6.27 MiB/s, done.
Resolving deltas: 100% (340/340), done.
Error: Package version 6.0.0+sha.8c2017d doesn't satisfy requirements 5.7.1 based on PackageMetaData <type=library name=InkplateLibrary version=6.0.0+sha.8c2017d spec={'owner': None, 'id': None, 'name': 'Inkplate-Arduino-library', 'requirements': '5.7.1', 'uri': 'git+https://github.com/e-radionicacom/Inkplate-Arduino-library'}
```

It seems it is able to download only the latest version, and the build is stopped because it is not the one we are waiting for.

## What?
Move the InkPlate Arduino Library to the [6.0.0 version](https://github.com/SolderedElectronics/Inkplate-Arduino-library/releases/tag/6.0.0).

After this update, there are some compatibility errors:
<img width="794" alt="image" src="https://user-images.githubusercontent.com/139323/227737860-a67d5c1c-5517-4697-924f-b7f720f1f49f.png">

The PR is replacing:
* All the `MCP23017_INT_ADDR` with `MCP23017_INTFA`
* All the `display.mcpRegsInt` with `display.ioRegsInt`

## Warning/Problems?
After this update, I needed to disable the touchpad that it seemed very sensitive compared to what I had before. But it is maybe only my InkPlate.
Change 
```
#define TOUCHPAD_ENABLE false
```
within the `config.h` file.