### PR TITLE
bump inkplate library to v6.0.0, update needed expander functions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ lib_deps =
   ; >1.2.3 - any version greater than 1.2.3. >=, <, and <= are also possible
   ; >0.1.0,!=0.2.0,<0.3.0 - any version greater than 0.1.0, not equal to 0.2.0 and less than 0.3.0
   
-  https://github.com/e-radionicacom/Inkplate-Arduino-library @ 5.7.1
+  https://github.com/e-radionicacom/Inkplate-Arduino-library @ 6.0.0
   arduino-libraries/NTPClient @ 3.2.1 ; NTP client
   paulstoffregen/Time @ 1.6.1
   jchristensen/Timezone @ 1.2.4 ; for timezone and DST calculations
@@ -87,5 +87,5 @@ upload_flags =
 ; if using a diffent device be sure to change the extended enviroment
 extends = env:inkplate10
 lib_deps =
-  e-radionicacom/InkplateLibrary @ 5.7.1
+  e-radionicacom/InkplateLibrary @ 6.0.0
 build_src_filter= -<*> +<../vcom_src/>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -9,10 +9,10 @@
 // read a byte from the expander
 unsigned int readMCPRegister(const byte reg)
 {
-    Wire.beginTransmission(MCP23017_INT_ADDR);
+    Wire.beginTransmission(IO_INT_ADDR);
     Wire.write(reg);
     Wire.endTransmission();
-    Wire.requestFrom(MCP23017_INT_ADDR, 1);
+    Wire.requestFrom(IO_INT_ADDR, 1);
     return Wire.read();
 }
 
@@ -78,7 +78,7 @@ void checkButtons(void *params)
         if (button)
         {
             // clear the interrupt on the MCP
-            readMCPRegister(MCP23017_INTCAPB);
+            display.getINTstate(IO_INT_ADDR);
             lastDebounceTime = millis();
             button = false;
             delaySleep(10);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,9 +51,9 @@ void setup()
     display.begin();             // Init Inkplate library (you should call this function ONLY ONCE)
     display.rtcClearAlarmFlag(); // Clear alarm flag from any previous alarm
     // set which pads can allow wakeup
-    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD1, RISING);
-    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD2, RISING);
-    display.setIntPinInternal(MCP23017_INT_ADDR, display.mcpRegsInt, PAD3, RISING);
+    display.setIntPin(PAD1, RISING, IO_INT_ADDR);
+    display.setIntPin(PAD2, RISING, IO_INT_ADDR);
+    display.setIntPin(PAD3, RISING, IO_INT_ADDR);
     pinMode(WAKE_BUTTON, INPUT_PULLUP);
 
     // setup display

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -35,7 +35,7 @@ void gotoSleepNow()
 
     // set MCP interrupts
     if (TOUCHPAD_ENABLE)
-        display.setIntOutputInternal(MCP23017_INT_ADDR, display.mcpRegsInt, 1, false, false, HIGH);
+        display.setIntOutput(1, false, false, HIGH, IO_INT_ADDR);
     i2cEnd();
 
     // Go to sleep for TIME_TO_SLEEP seconds


### PR DESCRIPTION
Updated to the new library to be able to use the new hardware revision which contains a different expander