### PR TITLE
Fix expander i2c address and touchpad issues

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -9,10 +9,10 @@
 // read a byte from the expander
 unsigned int readMCPRegister(const byte reg)
 {
-    Wire.beginTransmission(MCP23017_INTFA);
+    Wire.beginTransmission(IO_INT_ADDR);
     Wire.write(reg);
     Wire.endTransmission();
-    Wire.requestFrom(MCP23017_INTFA, 1);
+    Wire.requestFrom(IO_INT_ADDR, 1);
     return Wire.read();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,9 +51,9 @@ void setup()
     display.begin();             // Init Inkplate library (you should call this function ONLY ONCE)
     display.rtcClearAlarmFlag(); // Clear alarm flag from any previous alarm
     // set which pads can allow wakeup
-    display.setIntPinInternal(MCP23017_INTFA, display.ioRegsInt, PAD1, RISING);
-    display.setIntPinInternal(MCP23017_INTFA, display.ioRegsInt, PAD2, RISING);
-    display.setIntPinInternal(MCP23017_INTFA, display.ioRegsInt, PAD3, RISING);
+    display.setIntPin(PAD1, RISING, IO_INT_ADDR);
+    display.setIntPin(PAD2, RISING, IO_INT_ADDR);
+    display.setIntPin(PAD3, RISING, IO_INT_ADDR);
     pinMode(WAKE_BUTTON, INPUT_PULLUP);
 
     // setup display

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -35,7 +35,7 @@ void gotoSleepNow()
 
     // set MCP interrupts
     if (TOUCHPAD_ENABLE)
-        display.setIntOutputInternal(MCP23017_INTFA, display.ioRegsInt, 1, false, false, HIGH);
+        display.setIntOutput(1, false, false, HIGH, IO_INT_ADDR);
     i2cEnd();
 
     // Go to sleep for TIME_TO_SLEEP seconds

--- a/vcom_src/vcom.cpp
+++ b/vcom_src/vcom.cpp
@@ -16,9 +16,6 @@ Inkplate display(INKPLATE_1BIT);
 double vcomVoltage;
 int EEPROMaddress = 0;
 
-// Internal registers of MCP
-uint8_t mcpRegsInt[22];
-
 
 void writeVCOMToEEPROM(double v);
 void eraseEEPROM();
@@ -54,7 +51,7 @@ void programEEPROM()
     if (EEPROM.read(EEPROMaddress) != 170)
     {
         Serial.println("Vcom being set...");
-        display.pinModeInternal(MCP23017_INTFA, mcpRegsInt, 6, INPUT_PULLUP);
+        display.pinModeInternal(IO_INT_ADDR, display.ioRegsInt, 6, INPUT_PULLUP);
         writeVCOMToEEPROM(vcomVoltage);
         EEPROM.write(EEPROMaddress, 170);
         EEPROM.commit();
@@ -92,10 +89,10 @@ void writeVCOMToEEPROM(double v)
     int vcomL = vcom & 0xFF;
     // First, we have to power up TPS65186
     // Pull TPS65186 WAKEUP pin to High
-    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 3, HIGH);
+    display.digitalWriteInternal(IO_INT_ADDR, display.ioRegsInt, 3, HIGH);
 
     // Pull TPS65186 PWR pin to High
-    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 4, HIGH);
+    display.digitalWriteInternal(IO_INT_ADDR, display.ioRegsInt, 4, HIGH);
     delay(10);
 
     // Send to TPS65186 first 8 bits of VCOM
@@ -113,23 +110,23 @@ void writeVCOMToEEPROM(double v)
     do
     {
         delay(1);
-    } while (display.digitalReadInternal(MCP23017_INTFA, mcpRegsInt, 6));
+    } while (display.digitalReadInternal(IO_INT_ADDR, display.ioRegsInt, 6));
 
     // Clear Interrupt flag by reading INT1 register
     readReg(0x07);
 
     // Now, power off whole TPS
     // Pull TPS65186 WAKEUP pin to Low
-    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 3, LOW);
+    display.digitalWriteInternal(IO_INT_ADDR, display.ioRegsInt, 3, LOW);
 
     // Pull TPS65186 PWR pin to Low
-    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 4, LOW);
+    display.digitalWriteInternal(IO_INT_ADDR, display.ioRegsInt, 4, LOW);
 
     // Wait a little bit...
     delay(1000);
 
     // Power up TPS again
-    display.digitalWriteInternal(MCP23017_INTFA, mcpRegsInt, 3, HIGH);
+    display.digitalWriteInternal(IO_INT_ADDR, display.ioRegsInt, 3, HIGH);
 
     delay(10);
 


### PR DESCRIPTION
MCP23017_INTFA is the register address, not the i2c bus addr. Using the newly introduced IO_INT_ADDR resolved also the touchpad sensivity problem mentioned in 6e512f72824ace4b47cf3539a510ad54e1c30a68. In main.c I made use of the library exposed function that leaves out dealing with the expander addresses completely.
(I am right now testing how this can also be incorporated in the checkBootPads - I will get a inkplate10v2 soon and that has a different expander chip)