### PR TITLE
raise battery low voltage a little to get better battery wearlevel

### DIFF
--- a/src/homeplate.h
+++ b/src/homeplate.h
@@ -138,9 +138,9 @@ void delaySleep(uint seconds);
 
 // Battery power thresholds
 #define BATTERY_VOLTAGE_HIGH 4.2		// for 3.7V nominal battery
-#define BATTERY_VOLTAGE_LOW 3.2			// cut-off is ~3.0V
-#define BATTERY_VOLTAGE_WARNING_SLEEP 3.15	// cut-off is around 3.0V
-#define BATTERY_PERCENT_WARNING 10		// =3,3V
+#define BATTERY_VOLTAGE_LOW 3.4			// cut-off is ~3.0V
+#define BATTERY_VOLTAGE_WARNING_SLEEP 3.2	// prevents deep discharge => longer battery live
+#define BATTERY_PERCENT_WARNING 10		// =3.48V
 
 // enable SD card (currently unused)
 #define USE_SDCARD false


### PR DESCRIPTION
After some more longterm tests, this gives a better battery wearlevel and a saver deep discharge prevention.