### PR TITLE
skip battery percentage calculation to avoid integer overflow

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,6 +2,9 @@
 
 uint getBatteryPercent(double voltage)
 {
+    if (voltage < BATTERY_VOLTAGE_LOW)
+        return 0;
+
     uint percentage = ((voltage - BATTERY_VOLTAGE_LOW) * 100.0) / (BATTERY_VOLTAGE_HIGH - BATTERY_VOLTAGE_LOW);
     if (percentage > 100)
         percentage = 100;


### PR DESCRIPTION
When readout voltage is below BATTERY_VOLTAGE_LOW (for example 3.37V < 3.4V), then an integer overflow
occurs in the calculation of uint percentage, leading to return 100%.