### PR TITLE
add datatype to factor to get uint64_t

### DIFF
--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -1,6 +1,6 @@
 #include "homeplate.h"
 
-#define uS_TO_S_FACTOR 1000000 // Conversion factor for micro seconds to seconds
+#define uS_TO_S_FACTOR 1000000ULL // Conversion factor for micro seconds to seconds
 #define SLEEP_TASK_PRIORITY 1
 #define TOUCHPAD_WAKE_MASK (int64_t(1) << GPIO_NUM_34)
 


### PR DESCRIPTION
See esp_sleep_enable_timer_wakeup(uint64_t time_in_us)

With uint32_t a maximum sleep time of ~4294s/71min is possible, before the counter wraps around.

Fixes #34