### PR TITLE
Fix enable defines (NTP, QR, MQTT)

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -475,7 +475,9 @@ void startMQTTTask()
   filter["refresh"] = true;
 
   mqttClient.setClientId(HOSTNAME);
+#ifdef MQTT_HOST
   mqttClient.setServer(MQTT_HOST, MQTT_PORT);
+#endif
 #ifdef MQTT_USER
   mqttClient.setCredentials(MQTT_USER, MQTT_PASSWORD);
 #endif

--- a/src/qr.cpp
+++ b/src/qr.cpp
@@ -4,12 +4,9 @@
 void serialPrintQR(QRCode qrcode);
 void renderQR(QRCode qrcode, uint32_t x, uint32_t y, uint32_t size);
 
+#ifdef QR_WIFI_NAME
 void displayWiFiQR()
 {
-    #ifndef QR_WIFI_NAME
-        // if not defined, exit early
-        return;
-    #endif
     Serial.printf("Rendering wifi QR Code\n");
     char buf[1024];
     snprintf(buf, 1024, "WIFI:S:%s;T:WPA;P:%s;;", QR_WIFI_NAME, QR_WIFI_PASSWORD);
@@ -47,6 +44,10 @@ void displayWiFiQR()
     displayEnd();
     i2cEnd();
 }
+#else
+// not used, just return
+void displayWiFiQR() { return; }
+#endif
 
 void renderQR(QRCode qrcode, uint32_t x, uint32_t y, uint32_t size)
 {

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -23,6 +23,7 @@ bool getNTPSynced()
     return ntpSynced;
 }
 
+#ifdef NTP_SERVER
 void ntpSync(void *parameter)
 {
     WiFiUDP ntpUDP;
@@ -78,6 +79,7 @@ void ntpSync(void *parameter)
     printDebugStackSpace();
     vTaskDelete(NULL); // end self task
 }
+#endif
 
 void setupTimeAndSyncTask()
 {


### PR DESCRIPTION
Fix to exclude certain modules (NTP, QR, MQTT) from running when variables are not defined in config.h

Fixes #33 