### PR TITLE
fix: set hostname before mode

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -54,11 +54,11 @@ void keepWiFiAlive(void *parameter)
         }
 
         Serial.println("[WIFI] Connecting...");
+        WiFi.setHostname(HOSTNAME); // only works with DHCP....
         WiFi.mode(WIFI_STA);
 #ifdef STATIC_IP
         WiFi.config(ip, gateway, subnet, dns);
 #endif
-        WiFi.setHostname(HOSTNAME); // only works with DHCP....
         WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
 
         unsigned long startAttemptTime = millis();


### PR DESCRIPTION
See https://github.com/espressif/arduino-esp32/issues/6278, setHostname needs to be called before setting the wifi  mode cause otherwise it will not / not always be set correctly