### PR TITLE
feat: make TIME_TO_QUICK_SLEEP_SEC user configurable

### DIFF
--- a/src/config_example.h
+++ b/src/config_example.h
@@ -12,6 +12,9 @@
 // How long to sleep between image refreshes
 #define TIME_TO_SLEEP_MIN 20
 
+// How long to sleep for quick activities like e.g. showing info and qr code (default 300 / 5 min)
+//#define TIME_TO_QUICK_SLEEP_SEC 30
+
 // Static IP information
 // If unset uses DHCP, but updates may be slower, set to use a Static IP
 // #define STATIC_IP "192.168.1.10"

--- a/src/homeplate.h
+++ b/src/homeplate.h
@@ -74,7 +74,9 @@ void setupWakePins();
 
 // Sleep
 #define TIME_TO_SLEEP_SEC (TIME_TO_SLEEP_MIN * 60)    // How long ESP32 will be in deep sleep (in seconds)
+#ifndef TIME_TO_QUICK_SLEEP_SEC
 #define TIME_TO_QUICK_SLEEP_SEC 5 * 60 // 5 minutes. How long ESP32 will be in deep sleep (in seconds) for short activities
+#endif
 void startSleep();
 void setSleepRefresh(uint32_t sec);
 void setSleepDuration(uint32_t sec);


### PR DESCRIPTION
The default timeout of 5 minutes for the qr code / info seemed a bit long to me, took some time to figure out where that 5 min timeout came from. This pr makes that setting clearly user configurable