### PR TITLE
feat: add support for variable sleep durations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
         run: pio pkg install
       - name: Use example config
         run: cp src/config_example.h src/config.h
+      - name: Run PlatformIO Tests
+        # empty target to prevent upload
+        run: pio test -e native
       - name: Run PlatformIO
         # empty target to prevent upload
         run: pio run -t ''

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.cache
 .pio/
 .vscode/c_cpp_properties.json
 .vscode/launch.json
+src/config.h
+src/config.cpp

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Copy `config_example.h` to `config.h` and add/change your settings.
 If you want your inkplate to sleep with different intervals, copy `config_example.cpp` to `config.cpp` and uncomment the 3 lines in `config.h` starting from `#include "sleep_duration.h"`. Then configure your sleepTimeBlocks.
 
 Note that time blocks do not span multiple days, this means that the *day of week* setting is similar to configuring a cronjob. F.e. the settings below should be read as *between Xam to Ypm on every weekday*, and **not** as *from monday Xam to friday Ypm*.
+
 ```cpp
 {
     // on every weekday sleep for 1 hour between 12am and 8am
@@ -134,11 +135,11 @@ Older Inkplates don't appear to ship with an updated waveform. I found waveform 
 
 The available unit tests use the 'native' environment and can be run by either:
 
-- running them manually
+* running them manually
 
 ```shell
 pio test -v
 ```
 
-- in VSCode use Testing -> native -> Run Test
-- in VSCode use PlatformIO -> Project Tasks -> native -> Advanced -> Test
+* in VSCode use Testing -> native -> Run Test
+* in VSCode use PlatformIO -> Project Tasks -> native -> Advanced -> Test

--- a/README.md
+++ b/README.md
@@ -43,9 +43,39 @@ Setup [sibbl](https://github.com/sibbl/)'s [hass-lovelace-kindle-screensaver](ht
 
 ### Inkplate
 
-Install [PlatformIO](https://platformio.org/). Then copy `src/config_example.h` to `src/config.h` and enter your settings.
+Install [PlatformIO](https://platformio.org/).
 
-Build & run with:
+#### Configuring
+
+Copy `config_example.h` to `config.h` and add/change your settings.
+
+##### Variable sleep intervals
+
+If you want your inkplate to sleep with different intervals, copy `config_example.cpp` to `config.cpp` and uncomment the 3 lines in `config.h` starting from `#include "sleep_duration.h"`. Then configure your sleepTimeBlocks.
+
+Note that time blocks do not span multiple days, this means that the *day of week* setting is similar to configuring a cronjob. F.e. the settings below should be read as *between Xam to Ypm on every weekday*, and **not** as *from monday Xam to friday Ypm*.
+```cpp
+{
+    // on every weekday sleep for 1 hour between 12am and 8am
+    .start_dow = 1, .start_hour = 0, .start_minute = 0,
+    .end_dow = 5, .end_hour = 8, .end_minute = 0,
+    .sleep_in_seconds = 3600
+},
+{
+    // on every weekday sleep for 5min between 8am and 8pm
+    .start_dow = 1, .start_hour = 8, .start_minute = 0,
+    .end_dow = 5, .end_hour = 20, .end_minute = 0,
+    .sleep_in_seconds = 300
+},
+{
+    // on every weekday sleep for 30min between 8pm and 12am
+    .start_dow = 1, .start_hour = 20, .start_minute = 0,
+    .end_dow = 5, .end_hour = 24, .end_minute = 0,
+    .sleep_in_seconds = 1800
+}
+```
+
+#### Build & run
 
 ```shell
 pio run

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Copy `config_example.h` to `config.h` and add/change your settings.
 
 ##### Variable sleep intervals
 
-If you want your inkplate to sleep with different intervals, copy `config_example.cpp` to `config.cpp` and uncomment the 3 lines in `config.h` starting from `#include "sleep_duration.h"`. Then configure your sleepTimeBlocks.
+If you want your inkplate to sleep with different intervals, copy `config_example.cpp` to `config.cpp` and uncomment the 3 lines in `config.h` starting from `#include "sleep_duration.h"`. Then configure your `sleepSchedule`.
 
-Note that time blocks do not span multiple days, this means that the *day of week* setting is similar to configuring a cronjob. F.e. the settings below should be read as *between Xam to Ypm on every weekday*, and **not** as *from monday Xam to friday Ypm*.
+Note that schedule slots do not span multiple days, this means that the *day of week* setting is similar to configuring a cronjob. F.e. the settings below should be read as *between Xam to Ypm on every weekday*, and **not** as *from monday Xam to friday Ypm*.
 
 ```cpp
 {

--- a/README.md
+++ b/README.md
@@ -99,3 +99,16 @@ Waveform load failed! Upload new waveform in EEPROM. Using default waveform.
 ```
 
 Older Inkplates don't appear to ship with an updated waveform. I found waveform 3 looks the best for mine.
+
+### Tests
+
+The available unit tests use the 'native' environment and can be run by either:
+
+- running them manually
+
+```shell
+pio test -v
+```
+
+- in VSCode use Testing -> native -> Run Test
+- in VSCode use PlatformIO -> Project Tasks -> native -> Advanced -> Test

--- a/lib/libhomeplate/src/sleep_duration.cpp
+++ b/lib/libhomeplate/src/sleep_duration.cpp
@@ -1,0 +1,25 @@
+#include "sleep_duration.h"
+
+uint getSleepDuration(SleepTimeBlock sleepTimeBlocks[], size_t size, TimeInfo time, SleepDefaults defaults, bool doQuickSleep)
+{
+    if (doQuickSleep) {
+        return defaults.quickSleep;
+    }
+
+    uint timeInMinutes = time.hour * 60 + time.minute;
+
+    for (int i = 0; i < size; i++) {
+        SleepTimeBlock b = sleepTimeBlocks[i];
+
+        if (time.dow >= b.start_dow && time.dow <= b.end_dow) {
+            uint startTimeInMinutes = b.start_hour * 60 + b.start_minute;
+            uint endTimeInMinutes = b.end_hour * 60 + b.end_minute;
+
+            if (timeInMinutes >= startTimeInMinutes && timeInMinutes < endTimeInMinutes) {
+                return b.sleep_in_seconds;
+            }
+        }
+    }
+
+    return defaults.normalSleep;
+}

--- a/lib/libhomeplate/src/sleep_duration.cpp
+++ b/lib/libhomeplate/src/sleep_duration.cpp
@@ -1,6 +1,6 @@
 #include "sleep_duration.h"
 
-uint getSleepDuration(SleepScheduleSlot sleepScheduleSlots[], size_t size, TimeInfo time, SleepDefaults defaults, bool doQuickSleep)
+uint getSleepDuration(SleepScheduleSlot sleepSchedule[], size_t size, TimeInfo time, SleepDefaults defaults, bool doQuickSleep)
 {
     if (doQuickSleep) {
         return defaults.quickSleep;
@@ -9,7 +9,7 @@ uint getSleepDuration(SleepScheduleSlot sleepScheduleSlots[], size_t size, TimeI
     uint timeInMinutes = time.hour * 60 + time.minute;
 
     for (int i = 0; i < size; i++) {
-        SleepScheduleSlot b = sleepScheduleSlots[i];
+        SleepScheduleSlot b = sleepSchedule[i];
 
         if (time.dow >= b.start_dow && time.dow <= b.end_dow) {
             uint startTimeInMinutes = b.start_hour * 60 + b.start_minute;

--- a/lib/libhomeplate/src/sleep_duration.cpp
+++ b/lib/libhomeplate/src/sleep_duration.cpp
@@ -1,6 +1,6 @@
 #include "sleep_duration.h"
 
-uint getSleepDuration(SleepTimeBlock sleepTimeBlocks[], size_t size, TimeInfo time, SleepDefaults defaults, bool doQuickSleep)
+uint getSleepDuration(SleepScheduleSlot sleepScheduleSlots[], size_t size, TimeInfo time, SleepDefaults defaults, bool doQuickSleep)
 {
     if (doQuickSleep) {
         return defaults.quickSleep;
@@ -9,7 +9,7 @@ uint getSleepDuration(SleepTimeBlock sleepTimeBlocks[], size_t size, TimeInfo ti
     uint timeInMinutes = time.hour * 60 + time.minute;
 
     for (int i = 0; i < size; i++) {
-        SleepTimeBlock b = sleepTimeBlocks[i];
+        SleepScheduleSlot b = sleepScheduleSlots[i];
 
         if (time.dow >= b.start_dow && time.dow <= b.end_dow) {
             uint startTimeInMinutes = b.start_hour * 60 + b.start_minute;

--- a/lib/libhomeplate/src/sleep_duration.h
+++ b/lib/libhomeplate/src/sleep_duration.h
@@ -23,6 +23,6 @@ struct SleepDefaults {
     uint quickSleep;
 };
 
-uint getSleepDuration(SleepScheduleSlot sleepScheduleSlots[], size_t size, TimeInfo time, SleepDefaults sleep, bool doQuickSleep = false);
+uint getSleepDuration(SleepScheduleSlot sleepSchedule[], size_t size, TimeInfo time, SleepDefaults sleep, bool doQuickSleep = false);
 
 #endif

--- a/lib/libhomeplate/src/sleep_duration.h
+++ b/lib/libhomeplate/src/sleep_duration.h
@@ -2,7 +2,7 @@
 #define UTIL_SLEEP_DURATION_H
 #include <Arduino.h>
 
-struct SleepTimeBlock {
+struct SleepScheduleSlot {
     int start_dow; // 1-7, 1=monday
     int start_hour; // 0-24
     int start_minute; // 0-59
@@ -23,6 +23,6 @@ struct SleepDefaults {
     uint quickSleep;
 };
 
-uint getSleepDuration(SleepTimeBlock sleepTimeBlocks[], size_t size, TimeInfo time, SleepDefaults sleep, bool doQuickSleep = false);
+uint getSleepDuration(SleepScheduleSlot sleepScheduleSlots[], size_t size, TimeInfo time, SleepDefaults sleep, bool doQuickSleep = false);
 
 #endif

--- a/lib/libhomeplate/src/sleep_duration.h
+++ b/lib/libhomeplate/src/sleep_duration.h
@@ -13,9 +13,9 @@ struct SleepTimeBlock {
 };
 
 struct TimeInfo {
-    uint dow;
-    uint hour;
-    uint minute;
+    int dow;
+    int hour;
+    int minute;
 };
 
 struct SleepDefaults {

--- a/lib/libhomeplate/src/sleep_duration.h
+++ b/lib/libhomeplate/src/sleep_duration.h
@@ -4,7 +4,7 @@
 
 struct SleepTimeBlock {
     int start_dow; // 1-7, 1=monday
-    int start_hour; // 0-23
+    int start_hour; // 0-24
     int start_minute; // 0-59
     int end_dow;
     int end_hour;

--- a/lib/libhomeplate/src/sleep_duration.h
+++ b/lib/libhomeplate/src/sleep_duration.h
@@ -1,0 +1,28 @@
+#ifndef UTIL_SLEEP_DURATION_H
+#define UTIL_SLEEP_DURATION_H
+#include <Arduino.h>
+
+struct SleepTimeBlock {
+    int start_dow; // 1-7, 1=monday
+    int start_hour; // 0-23
+    int start_minute; // 0-59
+    int end_dow;
+    int end_hour;
+    int end_minute;
+    uint sleep_in_seconds;
+};
+
+struct TimeInfo {
+    uint dow;
+    uint hour;
+    uint minute;
+};
+
+struct SleepDefaults {
+    uint normalSleep;
+    uint quickSleep;
+};
+
+uint getSleepDuration(SleepTimeBlock sleepTimeBlocks[], size_t size, TimeInfo time, SleepDefaults sleep, bool doQuickSleep = false);
+
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,7 +3,7 @@ default_envs = inkplate10
 ; set the below to add an "include" dir to the build path
 include_dir =
 
-[env]
+[env:inkplate_defaults]
 ; default enviroments for inkplate devices
 platform = espressif32
 framework = arduino
@@ -47,17 +47,20 @@ build_flags =
 
 [env:inkplate10]
 ; settings for inkplate10
+extends = env:inkplate_defaults
 build_flags =
   ${env.build_flags}
   -DARDUINO_INKPLATE10
 
 [env:inkplate10v2]
-; settings for inkplate10
+; settings for inkplate10v2
+extends = env:inkplate_defaults
 build_flags =
   ${env.build_flags}
   -DARDUINO_INKPLATE10V2
 
 [env:debug]
+extends = env:inkplate_defaults
 build_type = debug
 build_flags =
   ${env.build_flags}
@@ -92,3 +95,9 @@ extends = env:inkplate10
 lib_deps =
   e-radionicacom/InkplateLibrary#7.0.0
 build_src_filter= -<*> +<../vcom_src/>
+
+[env:native]
+platform = native
+build_flags = -std=gnu++11
+lib_deps =
+  ArduinoFake

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,7 +3,7 @@ default_envs = inkplate10
 ; set the below to add an "include" dir to the build path
 include_dir =
 
-[env:inkplate_defaults]
+[inkplate_defaults]
 ; default enviroments for inkplate devices
 platform = espressif32
 framework = arduino
@@ -47,23 +47,23 @@ build_flags =
 
 [env:inkplate10]
 ; settings for inkplate10
-extends = env:inkplate_defaults
+extends = inkplate_defaults
 build_flags =
-  ${env.build_flags}
+  ${inkplate_defaults.build_flags}
   -DARDUINO_INKPLATE10
 
 [env:inkplate10v2]
 ; settings for inkplate10v2
-extends = env:inkplate_defaults
+extends = inkplate_defaults
 build_flags =
-  ${env.build_flags}
+  ${inkplate_defaults.build_flags}
   -DARDUINO_INKPLATE10V2
 
 [env:debug]
-extends = env:inkplate_defaults
+extends = inkplate_defaults
 build_type = debug
 build_flags =
-  ${env.build_flags}
+  ${inkplate_defaults.build_flags}
   -DARDUINO_INKPLATE10 ; change if debugging another board
   -DCORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
     ; build_type = debug

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -81,7 +81,7 @@ void runActivities(void *params)
 
         Serial.printf("[ACTIVITY] starting activity: %d\n", activityNext);
         bool doQuickSleep = activityNext == GuestWifi || activityNext == Info;
-#ifdef sleepScheduleSlots
+#ifdef sleepSchedule
         TimeInfo time = {
             .dow = getDayOfWeek(true),
             .hour = getHour(),
@@ -91,7 +91,7 @@ void runActivities(void *params)
             .normalSleep = TIME_TO_SLEEP_SEC,
             .quickSleep = TIME_TO_QUICK_SLEEP_SEC,
         };
-        uint timeToSleep = getSleepDuration(sleepScheduleSlots, sleepScheduleSlotCount, time, defaults, doQuickSleep);
+        uint timeToSleep = getSleepDuration(sleepSchedule, sleepScheduleSize, time, defaults, doQuickSleep);
 #else
         uint timeToSleep = doQuickSleep ? TIME_TO_QUICK_SLEEP_SEC : TIME_TO_SLEEP_SEC;
 #endif

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -80,13 +80,25 @@ void runActivities(void *params)
         activityCount++;
 
         Serial.printf("[ACTIVITY] starting activity: %d\n", activityNext);
+        bool doQuickSleep = activityNext == GuestWifi || activityNext == Info;
+        TimeInfo time = {
+            .dow = getDayOfWeek(true),
+            .hour = getHour(),
+            .minute = getMinute(),
+        };
+        SleepDefaults defaults = {
+            .normalSleep = TIME_TO_SLEEP_SEC,
+            .quickSleep = TIME_TO_QUICK_SLEEP_SEC,
+        };
+        uint timeToSleep = getSleepDuration(sleepTimeBlocks, sleepTimeBlockCount, time, defaults, doQuickSleep);
+
         switch (activityNext)
         {
         case NONE:
             break;
         case HomeAssistant:
             delaySleep(15);
-            setSleepDuration(TIME_TO_SLEEP_SEC);
+            setSleepDuration(timeToSleep);
             // wait for wifi or reset activity
             waitForWiFiOrActivityChange();
             if (resetActivity)
@@ -100,19 +112,19 @@ void runActivities(void *params)
             // delaySleep(10);
             break;
         case GuestWifi:
-            setSleepDuration(TIME_TO_QUICK_SLEEP_SEC);
+            setSleepDuration(timeToSleep);
             displayWiFiQR();
             break;
         case Info:
-            setSleepDuration(TIME_TO_QUICK_SLEEP_SEC);
+            setSleepDuration(timeToSleep);
             displayInfoScreen();
             break;
         case Message:
-            setSleepDuration(TIME_TO_SLEEP_SEC);
+            setSleepDuration(timeToSleep);
             displayMessage();
             break;
         case IMG:
-            setSleepDuration(TIME_TO_SLEEP_SEC);
+            setSleepDuration(timeToSleep);
             waitForWiFiOrActivityChange();
             if (resetActivity)
             {

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -81,7 +81,7 @@ void runActivities(void *params)
 
         Serial.printf("[ACTIVITY] starting activity: %d\n", activityNext);
         bool doQuickSleep = activityNext == GuestWifi || activityNext == Info;
-#ifdef sleepTimeBlocks
+#ifdef sleepScheduleSlots
         TimeInfo time = {
             .dow = getDayOfWeek(true),
             .hour = getHour(),
@@ -91,7 +91,7 @@ void runActivities(void *params)
             .normalSleep = TIME_TO_SLEEP_SEC,
             .quickSleep = TIME_TO_QUICK_SLEEP_SEC,
         };
-        uint timeToSleep = getSleepDuration(sleepTimeBlocks, sleepTimeBlockCount, time, defaults, doQuickSleep);
+        uint timeToSleep = getSleepDuration(sleepScheduleSlots, sleepScheduleSlotCount, time, defaults, doQuickSleep);
 #else
         uint timeToSleep = doQuickSleep ? TIME_TO_QUICK_SLEEP_SEC : TIME_TO_SLEEP_SEC;
 #endif

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -81,6 +81,7 @@ void runActivities(void *params)
 
         Serial.printf("[ACTIVITY] starting activity: %d\n", activityNext);
         bool doQuickSleep = activityNext == GuestWifi || activityNext == Info;
+#ifdef sleepTimeBlocks
         TimeInfo time = {
             .dow = getDayOfWeek(true),
             .hour = getHour(),
@@ -91,6 +92,9 @@ void runActivities(void *params)
             .quickSleep = TIME_TO_QUICK_SLEEP_SEC,
         };
         uint timeToSleep = getSleepDuration(sleepTimeBlocks, sleepTimeBlockCount, time, defaults, doQuickSleep);
+#else
+        uint timeToSleep = doQuickSleep ? TIME_TO_QUICK_SLEEP_SEC : TIME_TO_SLEEP_SEC;
+#endif
 
         switch (activityNext)
         {

--- a/src/config_example.cpp
+++ b/src/config_example.cpp
@@ -1,0 +1,60 @@
+// NOTE: THIS FILE IS ONLY NEEDED WHEN CONFIGURING VARIABLE SLEEP
+// DURATIONS USING TIME BLOCKS. IF USING A SINGLE SLEEP DURATION THEN
+// THIS FILE CAN BE OMITTED
+// #include "config.h"
+
+// How long to sleep between image refreshes
+// - there is no validation of any kind, make sure your blocks are continuous
+// - time blocks should be configured per day
+// - dow = DayOfWeek, starts at 1 = Monday to 7 = Sunday
+// SleepTimeBlock sleepTimeBlocks[] = {
+    /* EXAMPLE BLOCKS
+    { // On each workday from 00:00 to 08:30 sleep for 1 hour
+        .start_dow = 1,
+        .start_hour = 0,
+        .start_minute = 0,
+        .end_dow = 5,
+        .end_hour = 8,
+        .end_minute = 30,
+        .sleep_in_seconds = 3600,
+    },
+    { // On each workday from 08:30 to 22:00 sleep for 5 minutes
+        .start_dow = 1,
+        .start_hour = 8,
+        .start_minute = 30,
+        .end_dow = 5,
+        .end_hour = 22,
+        .end_minute = 0,
+        .sleep_in_seconds = 300,
+    },
+    { // On each workday from 22:00 to 24:00 sleep for 30 minutes
+        .start_dow = 1,
+        .start_hour = 8,
+        .start_minute = 30,
+        .end_dow = 5,
+        .end_hour = 24,
+        .end_minute = 0,
+        .sleep_in_seconds = 1800,
+    },
+    { // On saturday & sunday from 00:00 to 09:30 sleep for 1 hour
+        .start_dow = 6,
+        .start_hour = 0,
+        .start_minute = 0,
+        .end_dow = 7,
+        .end_hour = 9,
+        .end_minute = 30,
+        .sleep_in_seconds = 3600,
+    },
+    { // On saturday & sunday from 09:30 to 24:00 sleep for 5 minutes
+        .start_dow = 6,
+        .start_hour = 9,
+        .start_minute = 30,
+        .end_dow = 7,
+        .end_hour = 24,
+        .end_minute = 0,
+        .sleep_in_seconds = 300,
+    },
+    */
+// };
+
+//const size_t sleepTimeBlockCount = sizeof(sleepTimeBlocks) / sizeof(sleepTimeBlocks[0]);

--- a/src/config_example.cpp
+++ b/src/config_example.cpp
@@ -7,7 +7,7 @@
 // - there is no validation of any kind, make sure your blocks are continuous
 // - time blocks should be configured per day
 // - dow = DayOfWeek, starts at 1 = Monday to 7 = Sunday
-// SleepScheduleSlot sleepScheduleSlots[] = {
+// SleepScheduleSlot sleepSchedule[] = {
     /* EXAMPLE BLOCKS
     { // On each workday from 00:00 to 08:30 sleep for 1 hour
         .start_dow = 1,
@@ -57,4 +57,4 @@
     */
 // };
 
-//const size_t sleepScheduleSlotCount = sizeof(sleepScheduleSlots) / sizeof(sleepScheduleSlots[0]);
+//const size_t sleepScheduleSize = sizeof(sleepSchedule) / sizeof(sleepSchedule[0]);

--- a/src/config_example.cpp
+++ b/src/config_example.cpp
@@ -1,11 +1,12 @@
-// NOTE: THIS FILE IS ONLY NEEDED WHEN CONFIGURING VARIABLE SLEEP
-// DURATIONS USING TIME BLOCKS. IF USING A SINGLE SLEEP DURATION THEN
-// THIS FILE CAN BE OMITTED
+// NOTE: THIS FILE IS ONLY NEEDED WHEN CONFIGURING A CUSTOM SLEEP
+// SCHEDULE.
+// IF USING A SINGLE/STATIC SLEEP DURATION THEN THIS FILE CAN BE OMITTED
 // #include "config.h"
 
 // How long to sleep between image refreshes
-// - there is no validation of any kind, make sure your blocks are continuous
-// - time blocks should be configured per day
+// - there is no validation of any kind, make sure your slots are continuous
+// - falls back to TIME_TO_SLEEP_MIN if your slots are not continuous
+// - a schedule slot is configured per day, i.e. cronjob style
 // - dow = DayOfWeek, starts at 1 = Monday to 7 = Sunday
 // SleepScheduleSlot sleepSchedule[] = {
     /* EXAMPLE BLOCKS

--- a/src/config_example.cpp
+++ b/src/config_example.cpp
@@ -7,7 +7,7 @@
 // - there is no validation of any kind, make sure your blocks are continuous
 // - time blocks should be configured per day
 // - dow = DayOfWeek, starts at 1 = Monday to 7 = Sunday
-// SleepTimeBlock sleepTimeBlocks[] = {
+// SleepScheduleSlot sleepScheduleSlots[] = {
     /* EXAMPLE BLOCKS
     { // On each workday from 00:00 to 08:30 sleep for 1 hour
         .start_dow = 1,
@@ -57,4 +57,4 @@
     */
 // };
 
-//const size_t sleepTimeBlockCount = sizeof(sleepTimeBlocks) / sizeof(sleepTimeBlocks[0]);
+//const size_t sleepScheduleSlotCount = sizeof(sleepScheduleSlots) / sizeof(sleepScheduleSlots[0]);

--- a/src/config_example.h
+++ b/src/config_example.h
@@ -1,4 +1,5 @@
 #pragma once
+#ifndef CONFIG_H
 
 // WiFi SSID
 #define WIFI_SSID "WiFi Network Name" 
@@ -11,6 +12,12 @@
 
 // How long to sleep between image refreshes
 #define TIME_TO_SLEEP_MIN 20
+
+// Configure sleep times for different time blocks
+// NOTE: configure the actual sleepTimeBlocks in config.cpp, see config_example.cpp
+//#include "sleep_duration.h"
+//extern SleepTimeBlock sleepTimeBlocks[];
+//extern const size_t sleepTimeBlockCount;
 
 // Static IP information
 // If unset uses DHCP, but updates may be slower, set to use a Static IP
@@ -62,3 +69,4 @@
 
 // keep this to signal the program has a valid config file
 #define CONFIG_H
+#endif

--- a/src/config_example.h
+++ b/src/config_example.h
@@ -17,10 +17,10 @@
 //#define TIME_TO_QUICK_SLEEP_SEC 300
 
 // Configure sleep times for different time blocks
-// NOTE: configure the actual sleepTimeBlocks in config.cpp, see config_example.cpp
-//#include "sleep_duration.h"
-//extern SleepTimeBlock sleepTimeBlocks[];
-//extern const size_t sleepTimeBlockCount;
+// NOTE: configure the actual sleep schedule in config.cpp, see config_example.cpp
+//#include "sleep_schedule.h"
+//extern SleepScheduleSlot sleepScheduleSlots[];
+//extern const size_t sleepScheduleSlotCount;
 
 // Static IP information
 // If unset uses DHCP, but updates may be slower, set to use a Static IP

--- a/src/config_example.h
+++ b/src/config_example.h
@@ -19,8 +19,8 @@
 // Configure sleep times for different time blocks
 // NOTE: configure the actual sleep schedule in config.cpp, see config_example.cpp
 //#include "sleep_schedule.h"
-//extern SleepScheduleSlot sleepScheduleSlots[];
-//extern const size_t sleepScheduleSlotCount;
+//extern SleepScheduleSlot sleepSchedule[];
+//extern const size_t sleepScheduleSize;
 
 // Static IP information
 // If unset uses DHCP, but updates may be slower, set to use a Static IP

--- a/src/config_example.h
+++ b/src/config_example.h
@@ -16,7 +16,7 @@
 // How long to sleep for quick activities like e.g. showing info and qr code (default 300 / 5 min)
 //#define TIME_TO_QUICK_SLEEP_SEC 300
 
-// Configure sleep times for different time blocks
+// Configure a custom sleep schedule
 // NOTE: configure the actual sleep schedule in config.cpp, see config_example.cpp
 //#include "sleep_schedule.h"
 //extern SleepScheduleSlot sleepSchedule[];

--- a/src/config_example.h
+++ b/src/config_example.h
@@ -72,7 +72,4 @@
 
 // keep this to signal the program has a valid config file
 #define CONFIG_H
-<<<<<<< HEAD
 #endif
-=======
->>>>>>> main

--- a/src/homeplate.h
+++ b/src/homeplate.h
@@ -87,9 +87,9 @@ void setupTimeAndSyncTask();
 bool getNTPSynced();
 String timeString();
 String fullDateString();
-uint getDayOfWeek(bool weekStartsOnMonday = false);
-uint getHour();
-uint getMinute();
+int getDayOfWeek(bool weekStartsOnMonday = false);
+int getHour();
+int getMinute();
 
 // MQTT
 void startMQTTTask();

--- a/src/homeplate.h
+++ b/src/homeplate.h
@@ -6,6 +6,7 @@
 #include "fonts/Roboto_32.h"
 #include "fonts/Roboto_64.h"
 #include "fonts/Roboto_128.h"
+#include "sleep_duration.h"
 #include "config.h"
 
 // check that config file is correctly set
@@ -75,6 +76,7 @@ void setupWakePins();
 // Sleep
 #define TIME_TO_SLEEP_SEC (TIME_TO_SLEEP_MIN * 60)    // How long ESP32 will be in deep sleep (in seconds)
 #define TIME_TO_QUICK_SLEEP_SEC 5 * 60 // 5 minutes. How long ESP32 will be in deep sleep (in seconds) for short activities
+
 void startSleep();
 void setSleepRefresh(uint32_t sec);
 void setSleepDuration(uint32_t sec);
@@ -85,6 +87,9 @@ void setupTimeAndSyncTask();
 bool getNTPSynced();
 String timeString();
 String fullDateString();
+uint getDayOfWeek(bool weekStartsOnMonday = false);
+uint getHour();
+uint getMinute();
 
 // MQTT
 void startMQTTTask();

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -15,7 +15,7 @@
 AsyncMqttClient mqttClient;
 xTaskHandle mqttTaskHandle;
 bool mqttFailed = false;
-StaticJsonDocument<200> filter;
+JsonDocument filter;
 
 static bool mqttWaiting; // is MQTT waiting for status to be sent
 static bool mqttRun;     // should another MQTT status update be sent
@@ -62,8 +62,7 @@ void mqttSendWiFiStatus()
     return;
   }
 
-  const int capacity = JSON_OBJECT_SIZE(1);
-  StaticJsonDocument<capacity> doc;
+  JsonDocument doc;
   doc["signal"] = rssi;
   char buff[256];
   serializeJson(doc, buff);
@@ -88,8 +87,7 @@ void mqttSendTempStatus()
   }
 
   char buff[256];
-  const int capacity = JSON_OBJECT_SIZE(1);
-  StaticJsonDocument<capacity> doc;
+  JsonDocument doc;
   doc["temperature"] = temperature;
   serializeJson(doc, buff);
   Serial.printf("[MQTT] Sending MQTT State: [%s] %s\n", state_topic_temperature, buff);
@@ -114,8 +112,7 @@ void mqttSendBatteryStatus()
   }
 
   char buff[256];
-  const int capacity = JSON_OBJECT_SIZE(2);
-  StaticJsonDocument<capacity> doc;
+  JsonDocument doc;
   doc["voltage"] = voltage;
   doc["battery"] = percent;
   serializeJson(doc, buff);
@@ -126,8 +123,7 @@ void mqttSendBatteryStatus()
 void mqttSendBootStatus(uint boot, uint activityCount, const char *bootReason)
 {
   char buff[512];
-  const int capacity = JSON_OBJECT_SIZE(3);
-  StaticJsonDocument<capacity> doc;
+  JsonDocument doc;
   doc["boot"] = boot;
   doc["activity_count"] = activityCount;
   doc["boot_reason"] = bootReason;
@@ -147,8 +143,7 @@ void sendHAConfig()
   const bool retain = true;
   const int qos = 1;
   char buff[768];
-  const int capacity = JSON_OBJECT_SIZE(24); // intentionally larger than needed.
-  StaticJsonDocument<capacity> doc;
+  JsonDocument doc;
 
   // macaddr
   // need to copy macaddr because doc.clear() erases macaddr-pointer
@@ -156,8 +151,7 @@ void sendHAConfig()
   strncpy(macaddr, WiFi.macAddress().c_str(), 18);
 
   // deviceinfo
-  const int devCapacity = JSON_OBJECT_SIZE(7) + 32; // + sizeof(macaddr) + extra space matching obj size stepping
-  StaticJsonDocument<devCapacity> deviceInfo;
+  JsonDocument deviceInfo;
   deviceInfo.clear();
   deviceInfo["manufacturer"] = "e-radionica";
   deviceInfo["model"] = DEVICE_MODEL;
@@ -372,7 +366,7 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
     // send blank response to clear/ack the MQTT command
     mqttClient.publish(MQTT_ACTION_TOPIC, 1, true);
 
-    StaticJsonDocument<MESSAGE_BUFFER_SIZE> doc;
+    JsonDocument doc;
     DeserializationError error = deserializeJson(doc, payload, len, DeserializationOption::Filter(filter));
     if (error)
     {

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -123,3 +123,15 @@ String fullDateString() {
 String timeString() {
     return rtc.getTime("%H:%M");
 }
+
+uint getDayOfWeek(bool weekStartsOnMonday) {
+    return rtc.getDayofWeek() + (weekStartsOnMonday ? 1 : 0);
+}
+
+uint getHour() {
+    return rtc.getHour(true);
+}
+
+uint getMinute() {
+    return rtc.getMinute();
+}

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -9,6 +9,7 @@
 #define JAN_1_2000 946684800
 
 bool ntpSynced = false;
+bool rtcSet = false;
 
 ESP32Time rtc;
 
@@ -68,7 +69,7 @@ void ntpSync(void *parameter)
         Serial.printf("[TIME] synced local UNIX time Epoch(%ld) %s \n", localTime, fullDateString().c_str());
 
         i2cStart();
-        bool rtcSet = display.rtcIsSet();
+        rtcSet = display.rtcIsSet();
         i2cEnd();
         if (!rtcSet) {
             Serial.printf("[TIME] ERROR: Failed to set RTC!\n");
@@ -85,7 +86,7 @@ void setupTimeAndSyncTask()
 {
     unsigned long localTime = rtc.getLocalEpoch();
     i2cStart();
-    bool rtcSet = display.rtcIsSet();
+    rtcSet = display.rtcIsSet();
     if (rtcSet) {
         uint32_t rtcEpoch = display.rtcGetEpoch();
         rtc.offset = tzOffset(rtcEpoch);
@@ -124,14 +125,24 @@ String timeString() {
     return rtc.getTime("%H:%M");
 }
 
-uint getDayOfWeek(bool weekStartsOnMonday) {
+int getDayOfWeek(bool weekStartsOnMonday) {
+    if (!rtcSet) {
+        // return -1 as long as rtc is not set
+        return -1;
+    }
     return rtc.getDayofWeek() + (weekStartsOnMonday ? 1 : 0);
 }
 
-uint getHour() {
+int getHour() {
+    if (!rtcSet) {
+        return -1;
+    }
     return rtc.getHour(true);
 }
 
-uint getMinute() {
+int getMinute() {
+    if (!rtcSet) {
+        return -1;
+    }
     return rtc.getMinute();
 }

--- a/test/test_get_sleep_duration.cpp
+++ b/test/test_get_sleep_duration.cpp
@@ -132,6 +132,17 @@ void test_unconfigured_block(void) {
     TEST_ASSERT_EQUAL(50, sleep);
 }
 
+void test_unset_rtc(void) {
+    TimeInfo time = {
+        .dow = -1,
+        .hour = -1,
+        .minute = -1
+    };
+
+    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    TEST_ASSERT_EQUAL(50, sleep);
+}
+
 int main( int argc, char **argv) {
     UNITY_BEGIN();
 
@@ -142,6 +153,7 @@ int main( int argc, char **argv) {
     RUN_TEST(test_saturday_morning_quick);
     RUN_TEST(test_saturday_night);
     RUN_TEST(test_unconfigured_block);
+    RUN_TEST(test_unset_rtc);
 
     UNITY_END();
 }

--- a/test/test_get_sleep_duration.cpp
+++ b/test/test_get_sleep_duration.cpp
@@ -1,0 +1,147 @@
+#include <unity.h>
+#include "sleep_duration.h"
+
+SleepTimeBlock testBlocks[] = {
+    {
+        .start_dow = 1,
+        .start_hour = 0,
+        .start_minute = 0,
+        .end_dow = 5,
+        .end_hour = 8,
+        .end_minute = 30,
+        .sleep_in_seconds = 10,
+    },
+    {
+        .start_dow = 1,
+        .start_hour = 8,
+        .start_minute = 30,
+        .end_dow = 5,
+        .end_hour = 24,
+        .end_minute = 0,
+        .sleep_in_seconds = 20,
+    },
+    {
+        .start_dow = 6,
+        .start_hour = 0,
+        .start_minute = 0,
+        .end_dow = 7,
+        .end_hour = 9,
+        .end_minute = 30,
+        .sleep_in_seconds = 30,
+    },
+    {
+        .start_dow = 6,
+        .start_hour = 9,
+        .start_minute = 30,
+        .end_dow = 7,
+        .end_hour = 24,
+        .end_minute = 0,
+        .sleep_in_seconds = 40,
+    },
+};
+
+const size_t testBlocksSize = sizeof(testBlocks) / sizeof(testBlocks[0]);
+
+SleepDefaults defaults = {
+    .normalSleep = 50,
+    .quickSleep = 60,
+};
+
+void setUp(void) {
+    // set stuff up here
+}
+
+void tearDown(void) {
+    // clean stuff up here
+}
+
+void test_tuesday_morning(void) {
+    TimeInfo time = {
+        .dow = 2,
+        .hour = 9,
+        .minute = 0
+    };
+
+    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    TEST_ASSERT_EQUAL(20, sleep);
+}
+
+void test_tuesday_morning_quick(void) {
+    TimeInfo time = {
+        .dow = 2,
+        .hour = 9,
+        .minute = 0
+    };
+
+    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, true);
+    TEST_ASSERT_EQUAL(60, sleep);
+}
+
+void test_tuesday_night(void) {
+    TimeInfo time = {
+        .dow = 2,
+        .hour = 1,
+        .minute = 30
+    };
+
+    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    TEST_ASSERT_EQUAL(10, sleep);
+}
+
+void test_saturday_morning(void) {
+    TimeInfo time = {
+        .dow = 6,
+        .hour = 9,
+        .minute = 0
+    };
+
+    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    TEST_ASSERT_EQUAL(30, sleep);
+}
+
+void test_saturday_morning_quick(void) {
+    TimeInfo time = {
+        .dow = 6,
+        .hour = 9,
+        .minute = 0
+    };
+
+    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, true);
+    TEST_ASSERT_EQUAL(60, sleep);
+}
+
+void test_saturday_night(void) {
+    TimeInfo time = {
+        .dow = 6,
+        .hour = 1,
+        .minute = 30
+    };
+
+    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    TEST_ASSERT_EQUAL(30, sleep);
+}
+
+void test_unconfigured_block(void) {
+    TimeInfo time = {
+        .dow = 10,
+        .hour = 1,
+        .minute = 30
+    };
+
+    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    TEST_ASSERT_EQUAL(50, sleep);
+}
+
+int main( int argc, char **argv) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_tuesday_morning);
+    RUN_TEST(test_tuesday_morning_quick);
+    RUN_TEST(test_tuesday_night);
+    RUN_TEST(test_saturday_morning);
+    RUN_TEST(test_saturday_morning_quick);
+    RUN_TEST(test_saturday_night);
+    RUN_TEST(test_unconfigured_block);
+
+    UNITY_END();
+}

--- a/test/test_get_sleep_duration.cpp
+++ b/test/test_get_sleep_duration.cpp
@@ -1,7 +1,7 @@
 #include <unity.h>
 #include "sleep_duration.h"
 
-SleepTimeBlock testBlocks[] = {
+SleepScheduleSlot testSlots[] = {
     {
         .start_dow = 1,
         .start_hour = 0,
@@ -40,7 +40,7 @@ SleepTimeBlock testBlocks[] = {
     },
 };
 
-const size_t testBlocksSize = sizeof(testBlocks) / sizeof(testBlocks[0]);
+const size_t testSlotCount = sizeof(testSlots) / sizeof(testSlots[0]);
 
 SleepDefaults defaults = {
     .normalSleep = 50,
@@ -62,7 +62,7 @@ void test_tuesday_morning(void) {
         .minute = 0
     };
 
-    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    uint sleep = getSleepDuration(testSlots, testSlotCount, time, defaults, false);
     TEST_ASSERT_EQUAL(20, sleep);
 }
 
@@ -73,7 +73,7 @@ void test_tuesday_morning_quick(void) {
         .minute = 0
     };
 
-    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, true);
+    uint sleep = getSleepDuration(testSlots, testSlotCount, time, defaults, true);
     TEST_ASSERT_EQUAL(60, sleep);
 }
 
@@ -84,7 +84,7 @@ void test_tuesday_night(void) {
         .minute = 30
     };
 
-    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    uint sleep = getSleepDuration(testSlots, testSlotCount, time, defaults, false);
     TEST_ASSERT_EQUAL(10, sleep);
 }
 
@@ -95,7 +95,7 @@ void test_saturday_morning(void) {
         .minute = 0
     };
 
-    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    uint sleep = getSleepDuration(testSlots, testSlotCount, time, defaults, false);
     TEST_ASSERT_EQUAL(30, sleep);
 }
 
@@ -106,7 +106,7 @@ void test_saturday_morning_quick(void) {
         .minute = 0
     };
 
-    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, true);
+    uint sleep = getSleepDuration(testSlots, testSlotCount, time, defaults, true);
     TEST_ASSERT_EQUAL(60, sleep);
 }
 
@@ -117,7 +117,7 @@ void test_saturday_night(void) {
         .minute = 30
     };
 
-    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    uint sleep = getSleepDuration(testSlots, testSlotCount, time, defaults, false);
     TEST_ASSERT_EQUAL(30, sleep);
 }
 
@@ -128,7 +128,7 @@ void test_unconfigured_block(void) {
         .minute = 30
     };
 
-    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    uint sleep = getSleepDuration(testSlots, testSlotCount, time, defaults, false);
     TEST_ASSERT_EQUAL(50, sleep);
 }
 
@@ -139,7 +139,7 @@ void test_unset_rtc(void) {
         .minute = -1
     };
 
-    uint sleep = getSleepDuration(testBlocks, testBlocksSize, time, defaults, false);
+    uint sleep = getSleepDuration(testSlots, testSlotCount, time, defaults, false);
     TEST_ASSERT_EQUAL(50, sleep);
 }
 


### PR DESCRIPTION
This PR adds support to configure different sleep durations per day-of-week, hour and minute. It should basically support the most common configs as is described in [hass.md](../blob/main/hass.md), so instead of using home-assistant to keep changing the sleep duration it's just baked into the homeplate fw :)

- see `config_example.cpp` for example config
- I had to change the env's a little bit to be able to run the unit tests