### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,13 +27,13 @@ lib_deps =
   ; >1.2.3 - any version greater than 1.2.3. >=, <, and <= are also possible
   ; >0.1.0,!=0.2.0,<0.3.0 - any version greater than 0.1.0, not equal to 0.2.0 and less than 0.3.0
   
-  https://github.com/e-radionicacom/Inkplate-Arduino-library#7.0.0
+  https://github.com/SolderedElectronics/Inkplate-Arduino-library#10.0.0
   arduino-libraries/NTPClient @ 3.2.1 ; NTP client
-  fbiego/ESP32Time @ 2.0.0 ; for syncing RTC to intenral clock
+  fbiego/ESP32Time @ 2.0.6 ; for syncing RTC to internal clock
   jchristensen/Timezone @ 1.2.4 ; for timezone and DST calculations
   ricmoo/QRCode @ 0.0.1 ; for QR code
   marvinroger/AsyncMqttClient @ 0.9.0 ; FOR MQTT
-  bblanchon/ArduinoJson @ 6.19.4 ; for JSON
+  bblanchon/ArduinoJson @ 7.1.0 ; for JSON
 
 ; set the default target to compile, upload, and monitor
 targets = upload, monitor


### PR DESCRIPTION
Both the Inkplate library as ESP32Time have some fixes. Not sure if homeplate is hitting any of those bugs, but upgrading doesn't seem to cause issues after testing.