### PR TITLE
fix: revert rename of sleep_duration.h in example config

### DIFF
--- a/src/config_example.h
+++ b/src/config_example.h
@@ -18,7 +18,7 @@
 
 // Configure a custom sleep schedule
 // NOTE: configure the actual sleep schedule in config.cpp, see config_example.cpp
-//#include "sleep_schedule.h"
+//#include "sleep_duration.h"
 //extern SleepScheduleSlot sleepSchedule[];
 //extern const size_t sleepScheduleSize;
 


### PR DESCRIPTION
As discussed [here](https://github.com/lanrat/homeplate/pull/45#issuecomment-2295172008), there's a wrong line in the example config that may confuse lib users.

This PR will revert the wrongful rename, thus making the project run when copying from the example config.