### PR TITLE
fix: sleep duration again & send sleep duration to mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ Copy `config_example.h` to `config.h` and add/change your settings.
 
 ##### Variable sleep intervals
 
-If you want your inkplate to sleep with different intervals, copy `config_example.cpp` to `config.cpp` and uncomment the 3 lines in `config.h` starting from `#include "sleep_duration.h"`. Then configure your `sleepSchedule`.
+If you want your inkplate to sleep with different intervals, copy `config_example.cpp` to `config.cpp` and uncomment the 4 lines in `config.h` starting from `#define CONFIG_CPP`. Then configure your `sleepSchedule` in config.cpp.
 
 Note that schedule slots do not span multiple days, this means that the *day of week* setting is similar to configuring a cronjob. F.e. the settings below should be read as *between Xam to Ypm on every weekday*, and **not** as *from monday Xam to friday Ypm*.
+
+To help with debugging the current sleep duration is also send to mqtt, so you can monitor it in home assistant.
 
 ```cpp
 {

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ To help with debugging the current sleep duration is also send to mqtt, so you c
 }
 ```
 
+##### MQTT Expiration
+
+MQTT data sent by homeplate will by default expire after `2 * TIME_TO_SLEEP_MIN`. When using a custom sleep schedule, this could mean that MQTT data expires before homeplate wakes up and sent new values. You should adjust `MQTT_EXPIRE_AFTER_SEC` in `config.h` to a value greater than your longest sleep schedule to avoid this.
+
 #### Build & run
 
 ```shell

--- a/hass.md
+++ b/hass.md
@@ -87,6 +87,8 @@ cards:
         secondary_info: last-updated
       - entity: sensor.homeplate_wifi_signal
         secondary_info: last-updated
+      - entity: sensor.homeplate_sleep_duration
+        secondary_info: last-updated
     title: HomePlate
     state_color: false
   - type: grid

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -4,6 +4,7 @@
 
 static bool resetActivity = false;
 uint activityCount = 0;
+uint timeToSleep = 60;
 
 QueueHandle_t activityQueue = xQueueCreate(1, sizeof(Activity));
 
@@ -91,9 +92,10 @@ void runActivities(void *params)
             .normalSleep = TIME_TO_SLEEP_SEC,
             .quickSleep = TIME_TO_QUICK_SLEEP_SEC,
         };
-        uint timeToSleep = getSleepDuration(sleepSchedule, sleepScheduleSize, time, defaults, doQuickSleep);
+        timeToSleep = getSleepDuration(sleepSchedule, sleepScheduleSize, time, defaults, doQuickSleep);
+        Serial.printf("[ACTIVITY SLEEP] Will sleep for %d\n", timeToSleep);
 #else
-        uint timeToSleep = doQuickSleep ? TIME_TO_QUICK_SLEEP_SEC : TIME_TO_SLEEP_SEC;
+        timeToSleep = doQuickSleep ? TIME_TO_QUICK_SLEEP_SEC : TIME_TO_SLEEP_SEC;
 #endif
 
         switch (activityNext)

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -93,7 +93,6 @@ void runActivities(void *params)
             .quickSleep = TIME_TO_QUICK_SLEEP_SEC,
         };
         timeToSleep = getSleepDuration(sleepSchedule, sleepScheduleSize, time, defaults, doQuickSleep);
-        Serial.printf("[ACTIVITY SLEEP] Will sleep for %d\n", timeToSleep);
 #else
         timeToSleep = doQuickSleep ? TIME_TO_QUICK_SLEEP_SEC : TIME_TO_SLEEP_SEC;
 #endif

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -4,7 +4,7 @@
 
 static bool resetActivity = false;
 uint activityCount = 0;
-uint timeToSleep = 60;
+uint timeToSleep = TIME_TO_SLEEP_SEC;
 
 QueueHandle_t activityQueue = xQueueCreate(1, sizeof(Activity));
 

--- a/src/config_example.cpp
+++ b/src/config_example.cpp
@@ -3,7 +3,6 @@
 //   If using a single/static sleep duration then this file can be omitted
 /* REMOVE THIS LINE TO ENABLE THE SLEEP SCHEDULE
 #include "config.h"
-#define CONFIG_CPP
 
 // How long to sleep between image refreshes
 // - there is no validation of any kind, make sure your slots are continuous

--- a/src/config_example.h
+++ b/src/config_example.h
@@ -16,6 +16,10 @@
 // How long to sleep for quick activities like e.g. showing info and qr code (default 300 / 5 min)
 //#define TIME_TO_QUICK_SLEEP_SEC 300
 
+// How long before MQTT entries expire (default 2 * TIME_TO_SLEEP_MIN)
+// When configuring a custom sleep schedule you might want to change this to a value greater than your longest sleep duration
+//#define MQTT_EXPIRE_AFTER_SEC 3600
+
 // Configure a custom sleep schedule
 // NOTE: configure the actual sleep schedule in config.cpp, see config_example.cpp
 //#define CONFIG_CPP

--- a/src/config_example.h
+++ b/src/config_example.h
@@ -18,6 +18,7 @@
 
 // Configure a custom sleep schedule
 // NOTE: configure the actual sleep schedule in config.cpp, see config_example.cpp
+//#define CONFIG_CPP
 //#include "sleep_duration.h"
 //extern SleepScheduleSlot sleepSchedule[];
 //extern const size_t sleepScheduleSize;

--- a/src/homeplate.h
+++ b/src/homeplate.h
@@ -21,7 +21,7 @@ extern void vApplicationStackOverflowHook(xTaskHandle *pxTask,
 extern Inkplate display;
 extern SemaphoreHandle_t mutexI2C, mutexDisplay, mutexSPI;
 extern bool sleepBoot;
-extern uint bootCount, activityCount;
+extern uint bootCount, activityCount, timeToSleep;
 
 #define i2cStart() xSemaphoreTake(mutexI2C, portMAX_DELAY)
 #define i2cEnd() xSemaphoreGive(mutexI2C)

--- a/src/homeplate.h
+++ b/src/homeplate.h
@@ -78,6 +78,9 @@ void setupWakePins();
 #ifndef TIME_TO_QUICK_SLEEP_SEC
 #define TIME_TO_QUICK_SLEEP_SEC 5 * 60 // 5 minutes. How long ESP32 will be in deep sleep (in seconds) for short activities
 #endif
+#ifndef MQTT_EXPIRE_AFTER_SEC
+#define MQTT_EXPIRE_AFTER_SEC (TIME_TO_SLEEP_SEC * 2)
+#endif
 
 void startSleep();
 void setSleepRefresh(uint32_t sec);

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -120,13 +120,14 @@ void mqttSendBatteryStatus()
   mqttClient.publish(state_topic_battery, 1, MQTT_RETAIN_SENSOR_VALUE, buff);
 }
 
-void mqttSendBootStatus(uint boot, uint activityCount, const char *bootReason)
+void mqttSendBootStatus(uint boot, uint activityCount, const char *bootReason, uint sleepDuration)
 {
   char buff[512];
   JsonDocument doc;
   doc["boot"] = boot;
   doc["activity_count"] = activityCount;
   doc["boot_reason"] = bootReason;
+  doc["sleep_duration"] = sleepDuration;
   serializeJson(doc, buff);
   Serial.printf("[MQTT] Sending MQTT State: [%s] %s\n", state_topic_boot, buff);
   mqttClient.publish(state_topic_boot, 1, MQTT_RETAIN_SENSOR_VALUE, buff);
@@ -259,6 +260,22 @@ void sendHAConfig()
   doc["device"] = deviceInfo;
   serializeJson(doc, buff);
   mqttClient.publish(mqtt_base_sensor("activity_count/config"), qos, retain, buff);
+
+  // sleepTime
+  doc.clear();
+  doc["unique_id"] = mqtt_unique_id("sleep_duration");
+  doc["state_class"] = "measurement";
+  doc["name"] = "Sleep Duration";
+  doc["state_topic"] = state_topic_boot;
+  doc["unit_of_measurement"] = "s";
+  doc["icon"] = "mdi:power-sleep";
+  doc["value_template"] = "{{ value_json.sleep_duration }}";
+  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["entity_category"] = "diagnostic";
+  doc["enabled_by_default"] = false;
+  doc["device"] = deviceInfo;
+  serializeJson(doc, buff);
+  mqttClient.publish(mqtt_base_sensor("sleep_duration/config"), qos, retain, buff);
 }
 
 void connectToMqtt(void *params)
@@ -521,7 +538,7 @@ void sendMQTTStatusTask(void *param)
     mqttWaiting = true;
 
     waitForMQTT();
-    mqttSendBootStatus(bootCount, activityCount, bootReason());
+    mqttSendBootStatus(bootCount, activityCount, bootReason(), timeToSleep);
     mqttSendWiFiStatus();
 
     mqttSendTempStatus();

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -170,7 +170,7 @@ void sendHAConfig()
   doc["state_topic"] = state_topic_wifi_signal;
   doc["unit_of_measurement"] = "dBm";
   doc["value_template"] = "{{ value_json.signal }}";
-  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["expire_after"] = MQTT_EXPIRE_AFTER_SEC;
   doc["entity_category"] = "diagnostic";
   doc["device"] = deviceInfo;
   serializeJson(doc, buff);
@@ -185,7 +185,7 @@ void sendHAConfig()
   doc["state_topic"] = state_topic_temperature;
   doc["unit_of_measurement"] = "°C";
   doc["value_template"] = "{{ value_json.temperature }}";
-  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["expire_after"] = MQTT_EXPIRE_AFTER_SEC;
   doc["device"] = deviceInfo;
   serializeJson(doc, buff);
   mqttClient.publish(mqtt_base_sensor("temperature/config"), qos, retain, buff);
@@ -199,7 +199,7 @@ void sendHAConfig()
   doc["state_topic"] = state_topic_battery;
   doc["unit_of_measurement"] = "V";
   doc["value_template"] = "{{ value_json.voltage }}";
-  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["expire_after"] = MQTT_EXPIRE_AFTER_SEC;
   doc["device"] = deviceInfo;
   serializeJson(doc, buff);
   mqttClient.publish(mqtt_base_sensor("voltage/config"), qos, retain, buff);
@@ -211,7 +211,7 @@ void sendHAConfig()
   doc["state_topic"] = state_topic_battery;
   doc["unit_of_measurement"] = "%";
   doc["value_template"] = "{{ value_json.battery }}";
-  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["expire_after"] = MQTT_EXPIRE_AFTER_SEC;
   doc["device"] = deviceInfo;
   serializeJson(doc, buff);
   mqttClient.publish(mqtt_base_sensor("battery/config"), qos, retain, buff);
@@ -225,7 +225,7 @@ void sendHAConfig()
   doc["unit_of_measurement"] = "boot";
   doc["icon"] = "mdi:chart-line-variant";
   doc["value_template"] = "{{ value_json.boot }}";
-  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["expire_after"] = MQTT_EXPIRE_AFTER_SEC;
   doc["entity_category"] = "diagnostic";
   doc["enabled_by_default"] = false;
   doc["device"] = deviceInfo;
@@ -238,7 +238,7 @@ void sendHAConfig()
   doc["name"] = "Boot Reason";
   doc["state_topic"] = state_topic_boot;
   doc["value_template"] = "{{ value_json.boot_reason }}";
-  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["expire_after"] = MQTT_EXPIRE_AFTER_SEC;
   doc["entity_category"] = "diagnostic";
   doc["enabled_by_default"] = false;
   doc["device"] = deviceInfo;
@@ -254,7 +254,7 @@ void sendHAConfig()
   doc["unit_of_measurement"] = "activities";
   doc["icon"] = "mdi:chart-line-variant";
   doc["value_template"] = "{{ value_json.activity_count }}";
-  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["expire_after"] = MQTT_EXPIRE_AFTER_SEC;
   doc["entity_category"] = "diagnostic";
   doc["enabled_by_default"] = false;
   doc["device"] = deviceInfo;
@@ -270,7 +270,7 @@ void sendHAConfig()
   doc["unit_of_measurement"] = "s";
   doc["icon"] = "mdi:power-sleep";
   doc["value_template"] = "{{ value_json.sleep_duration }}";
-  doc["expire_after"] = TIME_TO_SLEEP_SEC * 2;
+  doc["expire_after"] = MQTT_EXPIRE_AFTER_SEC;
   doc["entity_category"] = "diagnostic";
   doc["enabled_by_default"] = false;
   doc["device"] = deviceInfo;


### PR DESCRIPTION
Ok, third time is the charm 😞 

This is starting to get embarrassing, but in my defense I didn't realize before I had configured my `TIME_TO_SLEEP_MIN` to 5 minutes and also configured the variable sleep duration's during the day to be 5 minutes. So while I was working on this during the day, it seemed it was using the correct sleep duration even though it was just using the default sleep :(

As a similar issue could exists for other people when your configured time slots are f.e. not continuous, I realized it would be helpful to store the actual sleep duration as diagnostic in mqtt/hass so you can check it's correct even when you are normally sleeping.

I'll make this a draft pr for now and check tomorrow that it's actually fixed now...

fyi @felixh10r 