### PR TITLE
fix: dont send mqtt status twice during single activity

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -538,7 +538,7 @@ void sendMQTTStatusTask(void *param)
 void startMQTTStatusTask()
 {
   mqttWaiting = true;
-  mqttRun = true;
+  mqttRun = false;
   mqttKill = false;
 
   xTaskCreate(


### PR DESCRIPTION
Because `mqttRun` was true by default, it immediately sent a mqtt update when connecting to mqtt. But then after executing the activity (which homeplate always does after booting/waking up), it also sent a mqtt status which meant that mqtt data got updated twice every time the homeplate wakes up.

Not having to sent the mqtt data twice during a single wake up could improve battery life