### PR TITLE
update infodisplay when WiFi and MQTT become available

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -41,10 +41,6 @@ void displayBoundaryBox()
 
 void displayInfoScreen()
 {
-  // wait a little for the other threads to catch up
-  // get wifi connected, get mqtt connected, etc.
-  vTaskDelay(500 / portTICK_PERIOD_MS);
-
   Serial.printf("Rendering info page\n");
   static char buff[1024];
   esp_chip_info_t chip_info;

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -5,6 +5,10 @@
 #define COL2_NAME_X 5 * (E_INK_WIDTH / 8)
 #define COL2_DATA_X 6 * (E_INK_WIDTH / 8)
 
+#define REDRAW_NETWORK 0
+#define REDRAW_WIFI    1
+#define REDRAW_MQTT    2
+
 const static int lineHeight = 20;
 
 const char *wl_status_to_string(wl_status_t status)
@@ -39,9 +43,120 @@ void displayBoundaryBox()
   display.fillRect(0, E_INK_HEIGHT - 10, E_INK_WIDTH, 10, BLACK); // bottom
 }
 
+void cleanField(uint32_t x, uint32_t y)
+{
+  display.fillRect(x, y - lineHeight, (E_INK_WIDTH / 8), lineHeight, WHITE);
+  //Serial.printf("fillRect(x:%u, y:%u, w:%u, h:%u)\n", x, y, (E_INK_WIDTH / 8), lineHeight);
+}
+
+void drawNetwork(uint32_t *yref, bool clean)
+{
+  uint32_t y = *yref;
+
+  // network
+  display.setCursor(COL2_NAME_X, y);
+  display.print("Hostname:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(WiFi.getHostname());
+  // ip
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.print("IP Address:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(WiFi.localIP().toString().c_str());
+  // netmask
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.print("Subnet Mask:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(WiFi.subnetMask().toString().c_str());
+  // gateway
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.print("Gateway:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(WiFi.gatewayIP().toString().c_str());
+  // dns
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.print("DNS:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(WiFi.dnsIP(0).toString().c_str());
+  // mac
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.print("MAC Address:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(WiFi.macAddress().c_str());
+
+  *yref = y;
+}
+
+void drawWiFi(uint32_t *yref, bool clean)
+{
+  uint32_t y = *yref;
+
+  display.setCursor(COL2_NAME_X, y);
+  display.print("SSID:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(WiFi.SSID().c_str());
+  // bssid
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.print("BSSID:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(WiFi.BSSIDstr().c_str());
+  // signal
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.print("Signal:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.printf("%d dBm", WiFi.RSSI());
+  // wifi status
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.print("WiFi Status:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.print(wl_status_to_string(WiFi.status()));
+
+  *yref = y;
+}
+
+#ifdef MQTT_HOST
+void drawMQTT(uint32_t *yref, bool clean)
+{
+  uint32_t y = *yref;
+
+  display.setCursor(COL2_NAME_X, y);
+  display.printf("MQTT Server:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.printf(MQTT_HOST);
+  // MQTT status
+  y += lineHeight;
+  display.setCursor(COL2_NAME_X, y);
+  display.printf("MQTT Status:");
+  if (clean) { cleanField(COL2_DATA_X, y); };
+  display.setCursor(COL2_DATA_X, y);
+  display.printf(mqttConnected() ? "OK" : "Error");
+
+  *yref = y;
+}
+#endif
+
 void displayInfoScreen()
 {
-  Serial.printf("Rendering info page\n");
+  Serial.println("[INFO] Rendering info page");
   static char buff[1024];
   esp_chip_info_t chip_info;
   esp_chip_info(&chip_info);
@@ -149,79 +264,23 @@ void displayInfoScreen()
   // column 2
   y = 250;
   // network
-  display.setCursor(COL2_NAME_X, y);
-  display.print("Hostname:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(WiFi.getHostname());
-  // ip
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("IP Address:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(WiFi.localIP().toString().c_str());
-  // netmask
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("Subnet Mask:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(WiFi.subnetMask().toString().c_str());
-  // gateway
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("Gateway:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(WiFi.gatewayIP().toString().c_str());
-  // dns
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("DNS:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(WiFi.dnsIP(0).toString().c_str());
-  // mac
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("MAC Address:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(WiFi.macAddress().c_str());
+  uint32_t yNetwork = y;
+  drawNetwork(&y, false);
 
   // ssid
   y += lineHeight * 2;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("SSID:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(WiFi.SSID().c_str());
-  // bssid
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("BSSID:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(WiFi.BSSIDstr().c_str());
-  // signal
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("Signal:");
-  display.setCursor(COL2_DATA_X, y);
-  display.printf("%d dBm", WiFi.RSSI());
-  // wifi status
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.print("WiFi Status:");
-  display.setCursor(COL2_DATA_X, y);
-  display.print(wl_status_to_string(WiFi.status()));
+  uint32_t yWiFi = y;
+  bool stateWiFi = WiFi.isConnected();
+  drawWiFi(&y, false);
 
   #ifdef MQTT_HOST
   // MQTT server
   y += lineHeight * 2;
-  display.setCursor(COL2_NAME_X, y);
-  display.printf("MQTT Server:");
-  display.setCursor(COL2_DATA_X, y);
-  display.printf(MQTT_HOST);
-  // MQTT status
-  y += lineHeight;
-  display.setCursor(COL2_NAME_X, y);
-  display.printf("MQTT Status:");
-  display.setCursor(COL2_DATA_X, y);
-  display.printf(mqttConnected() ? "OK" : "Error");
+  uint32_t yMQTT = y;
+  bool stateMQTT = mqttConnected();
+  drawMQTT(&y, false);
+  #else
+  bool stateMQTT = true;
   #endif
 
   #ifdef NTP_SERVER
@@ -256,4 +315,82 @@ void displayInfoScreen()
   display.display();
   displayEnd();
   i2cEnd();
+
+  // check WiFi and MQTT state
+  uint8_t needsRedraw = 0;
+  for (int i = 0; i < 20; i++)
+  {
+    // only check if WiFi was not connected already
+    if (!stateWiFi)
+    {
+      if (WiFi.isConnected())
+      {
+        // schedule redraw for network and wifi
+	bitSet(needsRedraw, REDRAW_NETWORK);
+	bitSet(needsRedraw, REDRAW_WIFI);
+	stateWiFi = true;
+      }
+    }
+
+    #ifdef MQTT_HOST
+    // only check if MQTT was not connected already
+    if (!stateMQTT)
+    {
+      if (mqttConnected())
+      {
+        // schedule redraw for mqtt
+	bitSet(needsRedraw, REDRAW_MQTT);
+	stateMQTT = true;
+      }
+    }
+    #endif
+
+    // finish loop early if both are connected
+    if (stateWiFi && stateMQTT)
+    {
+      break;
+    }
+
+    // wait 100ms
+    vTaskDelay(100 / portTICK_PERIOD_MS);
+  }
+
+  // check for redraw
+  if (needsRedraw)
+  {
+    // start partial update
+    i2cStart();
+    displayStart();
+    display.selectDisplayMode(INKPLATE_1BIT);
+    display.setTextColor(BLACK, WHITE);
+    display.setTextSize(1);
+    display.setFont(&Roboto_16);
+    display.partialUpdate(sleepBoot);
+
+    if (bitRead(needsRedraw, REDRAW_NETWORK))
+    {
+      // redraw network
+      Serial.println("[INFO] Partial update: Network");
+      drawNetwork(&yNetwork, true);
+    }
+    if (bitRead(needsRedraw, REDRAW_WIFI))
+    {
+      // redraw wifi
+      Serial.println("[INFO] Partial update: WiFi");
+      drawWiFi(&yWiFi, true);
+    }
+    #ifdef MQTT_HOST
+    if (bitRead(needsRedraw, REDRAW_MQTT))
+    {
+      // redraw mqtt
+      Serial.println("[INFO] Partial update: MQTT");
+      drawMQTT(&yMQTT, true);
+    }
+    #endif
+
+    // send to display
+    display.partialUpdate(sleepBoot);
+    displayEnd();
+    i2cEnd();
+  }
 }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -41,6 +41,10 @@ void displayBoundaryBox()
 
 void displayInfoScreen()
 {
+  // wait a little for the other threads to catch up
+  // get wifi connected, get mqtt connected, etc.
+  vTaskDelay(500 / portTICK_PERIOD_MS);
+
   Serial.printf("Rendering info page\n");
   static char buff[1024];
   esp_chip_info_t chip_info;


### PR DESCRIPTION
When using the info display, it mostly shows an error for MQTT and WiFi due to the task running earlier/faster than the others. Around 500ms of delay seem to be sufficient to have the correct values there.