### PR TITLE
fix mqtt logic if no MQTT_HOST is defined

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -558,6 +558,13 @@ void startMQTTStatusTask()
   mqttRun = false;
   mqttKill = false;
 
+  #ifndef MQTT_HOST
+    // if no MQTT, return early
+    Serial.println("[MQTT] not starting status task, MQTT_HOST not defined");
+    mqttFailed = true;		// to avoid endless wait in sleep.cpp#86
+    return;
+  #endif
+
   xTaskCreate(
       sendMQTTStatusTask,      /* Task function. */
       "MQTT_STAT_TASK",        /* String with name of task. */


### PR DESCRIPTION
leads to endless sleep otherwise in [sleep.cpp#L86](https://github.com/lanrat/homeplate/blob/127031889d91811e4f3c0c8aae7ab8567cbac561/src/sleep.cpp#L86)